### PR TITLE
Fixed potential attribute mismatch

### DIFF
--- a/database/utils.py
+++ b/database/utils.py
@@ -14,7 +14,10 @@ def upsert_expansion(session: Session, expansion: PDExpansion):
         exclusions.append("id")
 
     index_elements = ["id" if expansion.id else "trigger"]
-    clean_expansion = expansion.model_dump(exclude=exclusions)
+    if hasattr(expansion, "model_dump"):
+        clean_expansion = expansion.model_dump(exclude=exclusions)
+    else:
+        clean_expansion = expansion.dict(exclude=exclusions)
     clean_tags = {tag.name for tag in expansion.tags}
 
     exp_stmt = (

--- a/database/utils.py
+++ b/database/utils.py
@@ -9,9 +9,9 @@ def upsert_expansion(session: Session, expansion: PDExpansion):
     # special consideration - if tag carries an id, then it should not be excluded
     # from the model dump, and included in the conflict index elements as "id" instead of "trigger"
 
-    exclusions = ["tags", "image_data"]
+    exclusions = {"tags", "image_data"}
     if not expansion.id:
-        exclusions.append("id")
+        exclusions |= {"id"}
 
     index_elements = ["id" if expansion.id else "trigger"]
     if hasattr(expansion, "model_dump"):


### PR DESCRIPTION
In the rare case where the venv already has pydantic pinned to v1.X and not v2.X (AND restores the deps automagically), we should use the deprecated v1 method to dump the model.